### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - name: Setup database
+    - name: Lint project
       run: bundle exec standardrb
   test:
     runs-on: ubuntu-latest
@@ -48,3 +48,4 @@ jobs:
       env:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/sample_blog_test
         RAILS_ENV: test
+        CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@
 
 # Ignore .vscode project file
 /.vscode/settings.json
+
+# Always ignore coverage directory
+/coverage/*
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "rack-cors"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "codecov"
+  gem "simplecov"
   gem "standard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,10 +67,13 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    codecov (0.5.1)
+      simplecov (>= 0.15, < 0.22)
     commonmarker (0.21.2)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    docile (1.3.5)
     erubi (1.10.0)
     ffi (1.15.0)
     github-markup (4.0.0)
@@ -178,6 +181,12 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.0)
       ffi (~> 1.12)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -207,6 +216,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
+  codecov
   commonmarker
   github-markup
   image_processing (~> 1.2)
@@ -217,6 +227,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 6.1.3, >= 6.1.3.1)
+  simplecov
   spring
   standard
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sample Blog
 
-![CI](https://github.com/HarvestProfit/sample-blog/workflows/CI Suite/badge.svg)
+![CI](https://github.com/HarvestProfit/sample-blog/workflows/CI%20Suite/badge.svg) [![codecov](https://codecov.io/gh/HarvestProfit/sample-blog/branch/main/graph/badge.svg?token=KSj36vyBgV)](https://codecov.io/gh/HarvestProfit/sample-blog)
 
 Incredibly simple api-only blog!
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,21 @@
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+SimpleCov.start "rails" do
+  enable_coverage :branch
+end
+
+if ENV["CODECOV_TOKEN"]
+  require "codecov"
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
+
 require_relative "../config/environment"
 require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  parallelize(workers: 1)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
Adds code coverage to the repo, and removes some unnecessary code.

For instance, this blog doesn't need to include `ActiveJob` or `ActionMailer`, but may need them in the future.